### PR TITLE
Add clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,69 @@
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     120
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+FixNamespaceComments: true
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     4
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInContainerLiterals: true
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never

--- a/src/controller/DirectoryGraph.cpp
+++ b/src/controller/DirectoryGraph.cpp
@@ -1,18 +1,15 @@
 #include "DirectoryGraph.h"
-#include <iostream>
 #include <algorithm>
-#include <string>
 #include <fstream>
+#include <iostream>
+#include <string>
 
 using namespace std;
 
-DirectoryGraph::DirectoryGraph(bool showHidden)
-    : showHidden(showHidden),
-    excludedDirectories()
-{
+DirectoryGraph::DirectoryGraph(bool showHidden) : showHidden(showHidden), excludedDirectories() {
     ifstream file(".dreeignore");
     string line;
-    
+
     while (getline(file, line)) {
         this->excludedDirectories.insert(line);
     }
@@ -21,62 +18,48 @@ DirectoryGraph::DirectoryGraph(bool showHidden)
     this->permissionErrorString = "Note:- Somefiles were omited due to default permission errors!!";
 }
 
-bool DirectoryGraph::isDirectory(const string &pathStr)
-{
+bool DirectoryGraph::isDirectory(const string &pathStr) {
     filesystem::path path(pathStr);
     return filesystem::is_directory(path);
 }
 
-bool DirectoryGraph::isExcluded(const string &dirStr)
-{
+bool DirectoryGraph::isExcluded(const string &dirStr) {
     return (dirStr.front() == '.' || excludedDirectories.find(dirStr) != excludedDirectories.end());
 }
 
-DirectoryNode *DirectoryGraph::BuildGraph(const string &directoryName, long long depth)
-{
+DirectoryNode *DirectoryGraph::BuildGraph(const string &directoryName, long long depth) {
     DirectoryNode *graph = new DirectoryNode(directoryName);
     TraverseDirectoriesDFS(graph, depth, 0);
     return graph;
 }
 
-void DirectoryGraph::TraverseDirectoriesDFS(DirectoryNode *node, long long depth, long long currentDepth)
-{
-    if (currentDepth > depth)
-        return;
+void DirectoryGraph::TraverseDirectoriesDFS(DirectoryNode *node, long long depth, long long currentDepth) {
+    if (currentDepth > depth) return;
 
-    try
-    {
-        for (const auto &entry : filesystem::directory_iterator(node->path))
-        {
-            if (!showHidden && isExcluded(entry.path().filename().string()))
-                continue;
+    try {
+        for (const auto &entry : filesystem::directory_iterator(node->path)) {
+            if (!showHidden && isExcluded(entry.path().filename().string())) continue;
 
             string childDirectory = entry.path().string();
             DirectoryNode *child = new DirectoryNode(childDirectory);
             node->children.push_back(child);
         }
-    }
-    catch (const std::exception &e)
-    {
+    } catch (const std::exception &e) {
         this->allFilesPermited = false;
     }
 
-    for (auto ch : node->children)
-    {
-        if (isDirectory(ch->path))
-        {
+    for (auto ch : node->children) {
+        if (isDirectory(ch->path)) {
             TraverseDirectoriesDFS(ch, depth, currentDepth + 1);
         }
     }
 }
 
-void DirectoryGraph::PrintGraphDFS(DirectoryNode *node, long long depth, long long currentDepth, bool isLastChild, long long mask)
-{
-    if (currentDepth == depth)
-        return;
+void DirectoryGraph::PrintGraphDFS(DirectoryNode *node, long long depth, long long currentDepth, bool isLastChild,
+                                   long long mask) {
+    if (currentDepth == depth) return;
 
-    for (long long i = 0; i < currentDepth; i++)
-    {
+    for (long long i = 0; i < currentDepth; i++) {
         if (((mask >> i) & 1ll) == 0ll)
             cout << "│    ";
         else
@@ -85,92 +68,68 @@ void DirectoryGraph::PrintGraphDFS(DirectoryNode *node, long long depth, long lo
     isLastChild ? cout << "└── " : cout << "├── ";
 
     cout << node->name << "\n";
-    for (size_t i = 0; i < node->children.size(); i++)
-    {
+    for (size_t i = 0; i < node->children.size(); i++) {
         DirectoryNode *child = node->children[i];
-        if (i == node->children.size() - 1)
-        {
+        if (i == node->children.size() - 1) {
             mask = mask | (1ll << (currentDepth + 1));
         }
         PrintGraphDFS(child, depth, currentDepth + 1, i == node->children.size() - 1, mask);
     }
 }
 
-void DirectoryGraph::PrintGraphDFS(DirectoryNode *node, long long depth)
-{
+void DirectoryGraph::PrintGraphDFS(DirectoryNode *node, long long depth) {
     this->PrintGraphDFS(node, depth, 0ll, true, 1ll);
 }
 
-void DirectoryGraph::TraverseDirectoriesToSearch(DirectoryNode *node, long long depth, long long currentDepth, const string &query, vector<pair<int, DirectoryNode *>> &results)
-{
-    if (currentDepth > depth)
-        return;
+void DirectoryGraph::TraverseDirectoriesToSearch(DirectoryNode *node, long long depth, long long currentDepth,
+                                                 const string &query, vector<pair<int, DirectoryNode *>> &results) {
+    if (currentDepth > depth) return;
 
     int score1 = DirectorySearch::LevenshteinDistance(node->name, query);
     int score2 = DirectorySearch::LevenshteinDistance(node->path, query);
-    if (score1 * 100 <= (50 * query.length()) || score2 * 100 <= (50 * query.length()))
-    {
+    if (score1 * 100 <= (50 * query.length()) || score2 * 100 <= (50 * query.length())) {
         results.push_back({min(score1, score2), node});
     }
 
-    if (!isDirectory(node->path))
-    {
+    if (!isDirectory(node->path)) {
         return;
     }
 
-    try
-    {
-        for (const auto &entry : filesystem::directory_iterator(node->path))
-        {
+    try {
+        for (const auto &entry : filesystem::directory_iterator(node->path)) {
             string childDirectory = entry.path().string();
             DirectoryNode *child = new DirectoryNode(childDirectory);
             node->children.push_back(child);
             TraverseDirectoriesToSearch(child, depth, currentDepth + 1, query, results);
         }
-    }
-    catch (const std::exception &e)
-    {
+    } catch (const std::exception &e) {
     }
 }
 
-void DirectoryGraph::SearchDirectory(const string &directoryName, int searchDepth, const string &query)
-{
+void DirectoryGraph::SearchDirectory(const string &directoryName, int searchDepth, const string &query) {
     DirectoryNode *currDir = new DirectoryNode(directoryName);
     DirectorySearch *searchObject = new DirectorySearch(searchDepth);
     this->TraverseDirectoriesToSearch(currDir, searchDepth, 0, query, searchObject->results);
     sort(searchObject->results.begin(), searchObject->results.end());
-    if (searchObject->results.empty())
-    {
+    if (searchObject->results.empty()) {
         cout << "No results found\n";
-    }
-    else
-    {
-        if (searchObject->results[0].first == 0)
-        {
+    } else {
+        if (searchObject->results[0].first == 0) {
             cout << "Search Results:\n";
             int cnt = 0;
-            for (auto res : searchObject->results)
-            {
-                if (res.first > 0)
-                    break;
+            for (auto res : searchObject->results) {
+                if (res.first > 0) break;
 
                 cout << cnt + 1 << ".\t";
-                cout << res.second->name << "\t\t"
-                     << res.second->path
-                     << "\n";
+                cout << res.second->name << "\t\t" << res.second->path << "\n";
                 cnt++;
             }
-        }
-        else
-        {
+        } else {
             cout << "Couldn't find results. Did you mean?:\n";
             int cnt = 0;
-            for (auto res : searchObject->results)
-            {
+            for (auto res : searchObject->results) {
                 cout << cnt + 1 << ".\t";
-                cout << res.second->name << "\t\t"
-                     << res.second->path
-                     << "\n";
+                cout << res.second->name << "\t\t" << res.second->path << "\n";
                 cnt++;
             }
         }

--- a/src/controller/DirectoryGraph.h
+++ b/src/controller/DirectoryGraph.h
@@ -1,18 +1,17 @@
 #ifndef DIRECTORYGRAPH_H
 #define DIRECTORYGRAPH_H
 
-#include <set>
-#include <vector>
-#include <string>
 #include <filesystem>
-#include "../model/DirectoryNode.h"
+#include <set>
+#include <string>
+#include <vector>
 #include "../controller/DirectorySearch.h"
+#include "../model/DirectoryNode.h"
 
 using namespace std;
 
-class DirectoryGraph
-{
-public:
+class DirectoryGraph {
+   public:
     DirectoryGraph(bool showHidden = false);
     DirectoryNode *BuildGraph(const string &directoryName, long long depth);
 
@@ -22,11 +21,12 @@ public:
     bool allFilesPermited;
     string permissionErrorString;
 
-private:
+   private:
     bool isDirectory(const string &pathStr);
     void TraverseDirectoriesDFS(DirectoryNode *node, long long depth, long long currentDepth = 0);
     void PrintGraphDFS(DirectoryNode *node, long long depth, long long currentDepth, bool isLastChild, long long mask);
-    void TraverseDirectoriesToSearch(DirectoryNode *node, long long depth, long long currentDepth, const string &query, vector<pair<int, DirectoryNode *>> &results);
+    void TraverseDirectoriesToSearch(DirectoryNode *node, long long depth, long long currentDepth, const string &query,
+                                     vector<pair<int, DirectoryNode *>> &results);
     bool isExcluded(const string &dirStr);
 
     set<string> excludedDirectories;

--- a/src/controller/DirectorySearch.cpp
+++ b/src/controller/DirectorySearch.cpp
@@ -1,30 +1,22 @@
+#include "DirectorySearch.h"
+#include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
-#include <algorithm>
-#include "DirectorySearch.h"
 
 using namespace std;
 
-DirectorySearch::DirectorySearch(int searchDepth)
-{
-    this->searchDepth = searchDepth;
-}
+DirectorySearch::DirectorySearch(int searchDepth) { this->searchDepth = searchDepth; }
 
-int DirectorySearch::LevenshteinDistance(const string &s1, const string &s2)
-{
+int DirectorySearch::LevenshteinDistance(const string &s1, const string &s2) {
     const int m = s1.length();
     const int n = s2.length();
     vector<vector<int>> dp(m + 1, vector<int>(n + 1, 0));
-    for (int i = 1; i <= m; ++i)
-        dp[i][0] = i;
-    for (int j = 1; j <= n; ++j)
-        dp[0][j] = j;
+    for (int i = 1; i <= m; ++i) dp[i][0] = i;
+    for (int j = 1; j <= n; ++j) dp[0][j] = j;
 
-    for (int i = 1; i <= m; ++i)
-    {
-        for (int j = 1; j <= n; ++j)
-        {
+    for (int i = 1; i <= m; ++i) {
+        for (int j = 1; j <= n; ++j) {
             if (s1[i - 1] == s2[j - 1])
                 dp[i][j] = dp[i - 1][j - 1];
             else

--- a/src/controller/DirectorySearch.h
+++ b/src/controller/DirectorySearch.h
@@ -1,16 +1,15 @@
 #ifndef DIRECTORYSEARCH_H
 #define DIRECTORYSEARCH_H
 
-#include <vector>
-#include <string>
 #include <filesystem>
+#include <string>
+#include <vector>
 #include "../model/DirectoryNode.h"
 
 using namespace std;
 
-class DirectorySearch
-{
-public:
+class DirectorySearch {
+   public:
     vector<pair<int, DirectoryNode *>> results;
     int searchDepth;
     DirectorySearch(int searchDepth = 60);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,31 +1,27 @@
-#include <iostream>
-#include <fstream>
-#include "model/DirectoryNode.h"
-#include "controller/DirectoryGraph.h"
-#include "view/Dree.h"
 #include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <string>
+#include "controller/DirectoryGraph.h"
+#include "model/DirectoryNode.h"
+#include "view/Dree.h"
 
 using namespace std;
 
-void search(int argc, char *argv[])
-{
-    if (argc != 5)
-    {
+void search(int argc, char *argv[]) {
+    if (argc != 5) {
         cout << "Missing args"
              << "\n";
         return;
     }
     string flag = argv[3];
-    if (flag != "-f")
-    {
+    if (flag != "-f") {
         cout << "Unknown args: " << argv[3] << "\n";
         return;
     }
     string query = argv[4];
     int depth = stoi(argv[2]);
-    if (depth >= 60)
-    {
+    if (depth >= 60) {
         cout << "mask overflow!!";
         return;
     }
@@ -35,10 +31,8 @@ void search(int argc, char *argv[])
     builder.SearchDirectory(currentPath, depth, query);
 }
 
-void dree(int argc, char *argv[])
-{
-    if (!(argc == 3 || argc == 4))
-    {
+void dree(int argc, char *argv[]) {
+    if (!(argc == 3 || argc == 4)) {
         cout << "Missing args" << std::endl;
         return;
     }
@@ -47,16 +41,15 @@ void dree(int argc, char *argv[])
     int depth = stoi(argv[2]);
 
     // TODO:add check to prevent overflow
-    if (depth >= 60)
-    {
+    if (depth >= 60) {
         cout << "mask overflow!!";
         return;
     }
 
     bool showHidden = false;
-    if(argc == 4) {
+    if (argc == 4) {
         string flag = argv[3];
-        if(flag == "-a") {
+        if (flag == "-a") {
             showHidden = true;
         } else {
             cout << "Unknown flags specified.";
@@ -68,12 +61,10 @@ void dree(int argc, char *argv[])
     auto root = builder.BuildGraph(currentPath, depth);
     builder.PrintGraphDFS(root, depth);
 
-    if (!builder.allFilesPermited)
-        cout << builder.permissionErrorString;
+    if (!builder.allFilesPermited) cout << builder.permissionErrorString;
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     if (argc < 5)
         dree(argc, argv);
     else if (argc == 5)

--- a/src/model/DirectoryNode.cpp
+++ b/src/model/DirectoryNode.cpp
@@ -2,18 +2,12 @@
 
 using namespace std;
 
-string DirectoryNode::getFileName(string path)
-{
+string DirectoryNode::getFileName(string path) {
     size_t lastSlash = path.find_last_of('/');
-    if (lastSlash != std::string::npos)
-    {
+    if (lastSlash != std::string::npos) {
         return path.substr(lastSlash + 1);
     }
     return path;
 }
 
-DirectoryNode::DirectoryNode(const string &path)
-    : path(path)
-{
-    this->name = this->getFileName(path);
-}
+DirectoryNode::DirectoryNode(const string &path) : path(path) { this->name = this->getFileName(path); }

--- a/src/model/DirectoryNode.h
+++ b/src/model/DirectoryNode.h
@@ -1,14 +1,13 @@
 #ifndef DIRECTORYNODE_H
 #define DIRECTORYNODE_H
 
-#include <vector>
 #include <string>
+#include <vector>
 
 using namespace std;
 
-class DirectoryNode
-{
-public:
+class DirectoryNode {
+   public:
     string name;
     string path;
     vector<DirectoryNode *> children;


### PR DESCRIPTION
This PR closes #5 

I've added the clang-format file with some styling options. You can add more or modify the existing ones by referring to the options [here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html).

To use this format, follow these steps:
1) Install `clang-format` on your machine.
2) Open Visual Studio Code and add these settings to your `settings.json` file:
``` yaml
"editor.formatOnSave": true,
"[cpp]": {
        "editor.defaultFormatter": "xaver.clang-format"
},
"clang-format.style": "file"
``` 
3) After making any modifications to your code, save it, and the formatting will be applied.