### PR TITLE
style: pass by `const` reference

### DIFF
--- a/src/data_structures/Args.cpp
+++ b/src/data_structures/Args.cpp
@@ -1,6 +1,6 @@
 #include "Args.h"
 
-Args::Args(long long dep, string path) {
+Args::Args(long long dep, const string& path) {
     MaxDepth = dep;
     currentPath = path;
 }

--- a/src/data_structures/Args.h
+++ b/src/data_structures/Args.h
@@ -9,7 +9,7 @@ class Args {
    public:
     long long MaxDepth;
     string currentPath;
-    Args(long long dep, string path);
+    Args(long long dep, const string& path);
 };
 
 #endif

--- a/src/data_structures/Error.cpp
+++ b/src/data_structures/Error.cpp
@@ -1,3 +1,5 @@
 #include "Error.h"
 
-Error::Error(std::string message) { this->message = message; };
+Error::Error(const std::string& message) {
+    this->message = message;
+};

--- a/src/data_structures/Error.h
+++ b/src/data_structures/Error.h
@@ -8,7 +8,7 @@ class Error {
     std::string message;
 
    public:
-    Error(std::string message);
+    Error(const std::string& message);
 };
 
 #endif


### PR DESCRIPTION
`std::string` is _expensive_ to copy. Passing by `const` reference is preferred in such case.