### PR TITLE
chore: generate dependency files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Compiler
 CC := g++
 # Compiler flags
-CFLAGS := -std=c++17
+CFLAGS := -std=c++17 -MMD -MP
 # Libraries
 LIBS := -lncurses
 


### PR DESCRIPTION
As discussed in #76, this PR changes the `Makefile`, so additional dependency files are generated.