### PR TITLE
style: declare single argument constructors as `explicit`

### DIFF
--- a/src/controller/HelpController.h
+++ b/src/controller/HelpController.h
@@ -7,7 +7,7 @@ class HelpController : public HelpControllerI {
     AboutDreeI* aboutInterface;
 
    public:
-    HelpController(AboutDreeI* aboutInterface);
+    explicit HelpController(AboutDreeI* aboutInterface);
 
     void help() override;
 };

--- a/src/data_structures/DreeNode.h
+++ b/src/data_structures/DreeNode.h
@@ -16,7 +16,7 @@ class DreeNode {
     DreeNode *left;
     DreeNode *right;
 
-    DreeNode(std::string &str);
+    explicit DreeNode(std::string &str);
 };
 
 #endif

--- a/src/model/DreeIgnore.h
+++ b/src/model/DreeIgnore.h
@@ -12,5 +12,5 @@ class DreeIgnore : public DreeIgnoreI {
    public:
     bool file_is_in_dree_ignore(string directoryString) override;
 
-    DreeIgnore(bool active);
+    explicit DreeIgnore(bool active);
 };

--- a/src/model/SearchDirectory.h
+++ b/src/model/SearchDirectory.h
@@ -21,7 +21,7 @@ class SearchDirectory : public SearchDirectoryI {
    public:
     vector<pair<int, DreeNode *>> search(DreeNode *root, string &query, DreeHelpersI *dreeHelpers) override;
 
-    SearchDirectory(Args *args);
+    explicit SearchDirectory(Args *args);
 };
 
 #endif

--- a/src/view/navigate/DreeNavigateView.h
+++ b/src/view/navigate/DreeNavigateView.h
@@ -21,7 +21,7 @@ class DreeNavigateView : public IDreeNavigateView {
    public:
     void navigate_dree(DreeNode* node, long long maxDepth) override;
 
-    DreeNavigateView(DreeHelpersI* dreehelper);
+    explicit DreeNavigateView(DreeHelpersI* dreehelper);
 };
 
 #endif


### PR DESCRIPTION
This PR declares all of the single argument constructors as `explicit`. This makes the _implicit conversion_ impossible. Cf.
- [C++ best practices](https://github.com/cpp-best-practices/cppbestpractices/blob/master/03-Style.md#single-parameter-constructors),
- [iso c++](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c46-by-default-declare-single-argument-constructors-explicit).